### PR TITLE
Receive appUrl from env variable instead of plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ To run the scripts, you can do:
 chmod +x generate-reports.js # give the file permission to be executed
 chmod +x parse-reports.js
 
-./generate-reports.js
-./parse-reports.js
+APP_URL="my-custom-url" ./generate-reports.js
+APP_URL="my-custom-url" ./parse-reports.js
 ```

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -2,7 +2,7 @@
 
 const execSync = require('child_process').execSync;
 
-const appUrl = 'https://7da41fee.ngrok.io';
+const appUrl = process.env.APP_URL;
 const reportOutputDir = 'hotjar';
 const howManyReports = 10; // Change this to be the number of tests you want to do
 


### PR DESCRIPTION
Hi folks!

I saw that the `appUrl` variable is a fixed string.
Would be nice to receive it as a env variable, improving flexibility and preventing any outside access.

This PR implements it and also updates the doc with this new usage.